### PR TITLE
dd support for using images as video input for clipcreator

### DIFF
--- a/biliwalle/clipcreator.py
+++ b/biliwalle/clipcreator.py
@@ -160,7 +160,7 @@ def make_clip_with_protocol(protocoldf, outdir,
         
         elif train_identifier in protocoldf.columns:
             # for training movie making with center object
-            p = videodir+"/%s_*"%row["Object"]
+            p = videodir+"/%s*"%row["Object"]
             video_fns = glob(p)
             assert len(video_fns) == 1, \
                 f"File pattern {p} is found {len(video_fns)} times, please make sure it's unique"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ here = pathlib.Path(__file__).parent.resolve()
 long_description = (here / 'README.md').read_text(encoding='utf-8')
 setup(
     name='biliwalle',
-    version='0.2dev',
+    version='0.3dev',
     description='Helper functions for the biliwoli project',
     long_description=long_description,
     long_description_content_type='text/markdown', 
@@ -19,7 +19,8 @@ setup(
     include_package_data=True,
     install_requires=['moviepy >= 2.0.0.dev2',
                        'pandas > 0.11',
-                       'PyYAML >= 5.4.1'],
+                       'PyYAML >= 5.4.1',
+                       "Pillow==9.5.0"],
     entry_points={
         'console_scripts': [
             'waveweaver=biliwalle.waveweaver:main',


### PR DESCRIPTION
1.  Add support for using images as video input for clipcreator
2.  Change how `audiodir` is specified in `clipcreator_config.yml`. 
     * No longer need the audios be in the `audiodir/subdir/`. It will find audios directly in `audiodir/`
3. Change how `Object`, `Left`, `Right` objects are found in `clipcreator`'s video/image filenames
    * No longer need `[Object]_` in the filename.  As long as `[Object]` is in the filename is fine.